### PR TITLE
2 files about dji-sdk-3.3 in onboard_computer/controller of this repo was mis-coding

### DIFF
--- a/onboard_computer/controller/djiros/src/djiros/DjiRosAuthority.cpp
+++ b/onboard_computer/controller/djiros/src/djiros/DjiRosAuthority.cpp
@@ -29,7 +29,7 @@ void DjiRos::on_authority_ack(Vehicle *vehicle,
   ACK::ErrorCode ack;
 
   ack.data = ErrorCode::CommonACK::NO_RESPONSE_ERROR;
-  if (recvFrame.recvInfo.len - OpenProtocol::PackageMin <= (int) sizeof(uint16_t)) {
+  if (recvFrame.recvInfo.len - Protocol::PackageMin <= (int) sizeof(uint16_t)) {
     ack.data = recvFrame.recvData.ack;
     ack.info = recvFrame.recvInfo;
   } else {

--- a/onboard_computer/controller/djiros/src/modules/dji_sdk_node_mobile_comm.cpp
+++ b/onboard_computer/controller/djiros/src/modules/dji_sdk_node_mobile_comm.cpp
@@ -16,7 +16,7 @@ void DJISDKNode::SDKfromMobileDataCallback(Vehicle *vehicle, RecvContainer recvF
 }
 
 void DJISDKNode::fromMobileDataCallback(RecvContainer recvFrame) {
-  int dataLength = recvFrame.recvInfo.len - OpenProtocol::PackageMin - 2;
+  int dataLength = recvFrame.recvInfo.len - Protocol::PackageMin - 2;
   if (dataLength <= 100) {
     DSTATUS( "Received mobile Data of len %d\n", recvFrame.recvInfo.len);
     dji_sdk::MobileData mobile_data;


### PR DESCRIPTION
2 files about dji-sdk-3.3 in `onboard_computer/controller` of this repo(`experiment` branch) was miscoding about `Protocol::PackageMin`, which will cause a compile error while $catkin_make. This branch has fixed the problem and ensuring $catkin_make passed.